### PR TITLE
fix: corrigir textos exibidos usuário

### DIFF
--- a/src/components/student/courses/[courseId]/modules/[moduleId]/codeVisualizer/index.tsx
+++ b/src/components/student/courses/[courseId]/modules/[moduleId]/codeVisualizer/index.tsx
@@ -217,7 +217,7 @@ export function CodeVisualizer({
     setActiveTab(2)
     if (result) {
       addToast({
-        message: 'Respota correta!',
+        message: 'Resposta correta!',
         icon: icons.success,
       })
     } else {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,7 @@ const Home: NextPage = () => {
           <div className="mx-auto w-2/3 py-8 text-center">
             <h2 className="text-4xl font-bold">
               Aprenda <span className="text-flowbite-blue">programação</span>{' '}
-              utilizando metodos de repetição{' '}
+              utilizando métodos de repetição{' '}
               <span className="text-flowbite-blue">
                 cientificamente comprovados
               </span>


### PR DESCRIPTION
Corrigidos:

- Na tela inicial:
palavra método está sem o acento

- Na validação de exercícios:
quando a resposta está correta está retornando "Respota correta", precisa ajustar o "Resposta"